### PR TITLE
Influx: populate selected message fields as tags

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,16 +40,6 @@ func LoadConf(path string) (MqttConf, InfluxDBConf, error) {
 		return MqttConf{}, InfluxDBConf{}, err
 	}
 
-	em := MqttConf{}
-	ei := InfluxDBConf{}
-
-	if cfg.Mqtt == em {
-		log.Fatal(`empty "mqforward-mqtt" configuration`)
-	}
-	if cfg.InfluxDB == ei {
-		log.Fatal(`empty "mqforward-influxdb" configuration`)
-	}
-
 	if cfg.General.Debug {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/mqforward.ini.example
+++ b/mqforward.ini.example
@@ -14,3 +14,4 @@ port = 8086
 db = test
 username = test
 password = password
+tagsAttributes = key1,key2


### PR DESCRIPTION
Turn user-defined message attributes into Influx tags instead of fields. This allows to use grouping functionality in InfluxDB.

