### PR TITLE
Acess InfluxDB via URL instead of hostname and port

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -20,6 +20,7 @@ const (
 type InfluxDBConf struct {
 	Hostname       string
 	Port           int
+	Url            string
 	Db             string
 	UserName       string
 	Password       string
@@ -43,7 +44,10 @@ type InfluxDBClient struct {
 }
 
 func NewInfluxDBClient(conf InfluxDBConf, ifChan chan Message, commandChan chan string) (*InfluxDBClient, error) {
-	host := fmt.Sprintf("http://%s:%d", conf.Hostname, conf.Port)
+	host := conf.Url
+	if len(host) == 0 {
+		host = fmt.Sprintf("http://%s:%d", conf.Hostname, conf.Port)
+	}
 	log.Infof("influxdb host: %s", host)
 
 	_, err := url.Parse(host)

--- a/mqforward.ini.example
+++ b/mqforward.ini.example
@@ -2,13 +2,15 @@
 debug = true
 
 [mqforward-mqtt]
-hostname= localhost
+hostname = localhost
 port = 1883
 username= ""
 password= ""
 topic = mqforward/#
 
 [mqforward-influxdb]
+# Use either URL or host name and port to configure how to connect to InfluxDB 
+# url = https://127.0.01/subpath
 hostname = 127.0.0.1
 port = 8086
 db = test


### PR DESCRIPTION
I have added a new configuration item called "url" that allows to directly configure a URL for InfluxDB. This enables accessing InfluxDB e.g. via SSL or via a reverse proxy.

Some examples for possible URL formats:

http://127.0.0.1:8086
https://127.0.1
https://1270.0.1/some/sub/path

If URL is not specified, hostname and port continue to be used as previously.